### PR TITLE
Add password hashing and JWT token for signup

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -280,6 +280,11 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+    },
     "binary-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",

--- a/server/src/routes/signup.router.js
+++ b/server/src/routes/signup.router.js
@@ -4,18 +4,61 @@
 const express = require('express');
 const signUpRouter = express.Router();
 const Account = require('../models/account.model'); // account model
+// JWT Authentication
+// After the user creates an account, a JWT token is signed to grant user access.
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
 
 /* Create a regular user account */
 signUpRouter.post("/regular", (req, res, next) => {
     let newAccount = {
         username: req.body.username,
         password: req.body.password,
-		email: req.body.email,
+		    email: req.body.email,
         group_ids: req.body.group_ids,
         is_supervisor: 0,
         managed_group_ids: req.body.managed_group_ids
-      }
-
+      };
+      
+      bcrypt.genSalt(10,(err,salt) => {
+        if(err) throw err;
+        bcrypt.hash(newAccount.password, salt,(err, hash) => {
+          if(err) throw err;
+          newAccount.password = hash;
+          //newAccount.save()
+          Account.create(newAccount, function(err, result){
+            if(err) throw err;
+            // sign the token
+            jwt.sign(
+              // payload info
+              {username:result.id,
+                email:result.email
+              },
+              process.env.JWT_SECRET,
+              // token expires 1 hour
+              {expiresIn:7200},
+              // call-back
+              (err,token) => {
+                if(err){
+                  res.status(400).send({
+                    success: false,
+                    error: err.message
+                  });
+                }
+                else {
+                  res.status(201).send({
+                      token:token,
+                      success: true,
+                      data: result,
+                      message: "Account created successfully"
+                  });
+                }
+              }
+            );  
+         });
+      });
+    }) 
+    /*
     Account.create(newAccount, function(err, result) {
     if(err){
         res.status(400).send({
@@ -29,15 +72,58 @@ signUpRouter.post("/regular", (req, res, next) => {
             message: "Account created successfully"
         });
     }
-  });
+    });
+    */
 });
 
 /* Create an admin user account */
 signUpRouter.post("/admin", (req, res, next) => {
+  bcrypt.genSalt(10,(err,salt) => {
+    if(err) throw err;
+    bcrypt.hash(req.body.password, salt,(err, hash) => {
+      if(err) throw err;
+      Account.create({
+        username: req.body.username,
+        password: hash,
+        email: req.body.email,
+        group_ids: req.body.group_ids,
+        is_supervisor: 1,
+        managed_group_ids: req.body.managed_group_ids
+       }, function(err, result) {
+        jwt.sign(
+          // payload info
+          {username:result.id,
+            email:result.email
+          },
+          process.env.JWT_SECRET,
+          // token expires 1 hour
+          {expiresIn:7200},
+          // call-back
+          (err,token) => {
+            if(err){
+              res.status(400).send({
+                success: false,
+                error: err.message
+              });
+            }
+            else {
+              res.status(201).send({
+                  token:token,
+                  success: true,
+                  data: result,
+                  message: "Account created successfully"
+              });
+            }
+          }
+        );  
+      });
+    });
+  });
+  /*
    Account.create({
     username: req.body.username,
     password: req.body.password,
-	email: req.body.email,
+	  email: req.body.email,
     group_ids: req.body.group_ids,
     is_supervisor: 1,
     managed_group_ids: req.body.managed_group_ids
@@ -55,6 +141,7 @@ signUpRouter.post("/admin", (req, res, next) => {
         });
     } 
   });
+  */
 });
 
 module.exports = signUpRouter;


### PR DESCRIPTION
For this commit, I have added hashing to the password of the user accounts(both admin and regular) with bcrypt.  
I also have implemented the JWT token signing for sign-up. When a new account is created, a JWT token will be given to account with a time duration of 7200 second.  After the token expires, the user needs to login again to get another token. However, for now I only print out the token after an account is successfully created. The JWT token signing will be further tested when the login and login out is implemented. 