### PR TITLE
Add the field is_supervisor to the token generated by signup and login

### DIFF
--- a/server/src/routes/auth.router.js
+++ b/server/src/routes/auth.router.js
@@ -5,6 +5,40 @@ var Account = require('../models/account.model');
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcryptjs');
 
+authRouter.post('/', verifyToken, (req, res) => {  
+    jwt.verify(req.token, process.env.JWT_SECRET, (err, authData) => {
+      if(err) {
+        res.sendStatus(403);
+      } else {
+        res.json({
+          validated: 1,
+        });
+      }
+    });
+  });
+  
+  
+  function verifyToken(req, res, next) {
+    // Get auth header value
+    const bearerHeader = req.headers['authorization'];
+    // Check if bearer is undefined
+    if(typeof bearerHeader !== 'undefined') {
+      // Split at the space
+      const bearer = bearerHeader.split(' ');
+      // Get token from array
+      const bearerToken = bearer[1];
+      // Set the token
+      req.token = bearerToken;
+      // Next middleware
+      next();
+    } else {
+      // Forbidden
+      res.sendStatus(403);
+    }
+  
+  }
+  
+  
 authRouter.post('/admin_login', (req,res) =>{
     // check '@' string
     const username_email = req.body.user_or_email;    ;
@@ -69,7 +103,8 @@ authRouter.post('/admin_login', (req,res) =>{
                         // payload info
                         { 
                           username:user.username,
-                          email:user.email
+                          email:user.email,
+                          is_supervisor:user.is_supervisor
                         },
                         process.env.JWT_SECRET,
                         // token expires 1 hour

--- a/server/src/routes/signup.router.js
+++ b/server/src/routes/signup.router.js
@@ -12,7 +12,6 @@ const bcrypt = require('bcryptjs');
 /* Create a regular user account */
 signUpRouter.post("/regular", (req, res, next) => {
     let newAccount = {
-       // no @ for username
         username: req.body.username,
         password: req.body.password,
 		    email: req.body.email,
@@ -52,7 +51,8 @@ signUpRouter.post("/regular", (req, res, next) => {
               // payload info
               { 
                 username:result.username,
-                email:result.email
+                email:result.email,
+                is_supervisor: 0
               },
               process.env.JWT_SECRET,
               // token expires 1 hour
@@ -132,8 +132,9 @@ signUpRouter.post("/admin", (req, res, next) => {
         jwt.sign(
           // payload info
           { 
-            username:result.username,
-            email:result.email
+            username:result.id,
+            email:result.email,
+            is_supervisor:1
           },
           process.env.JWT_SECRET,
           // token expires 1 hour


### PR DESCRIPTION
This commit adds the field is_supervisor to the token generated by signup and login.  Earlier commits for '/' page of auth router is also added