### PR TITLE
Comment deletion

### DIFF
--- a/server/src/models/comment.model.js
+++ b/server/src/models/comment.model.js
@@ -21,7 +21,11 @@ const commentSchema = new mongoose.Schema({
     created: {
         type: Date,
         required: true
-    }
+    },
+    post_owner: {
+        type: String,
+        required: true
+   } 
 });
 
 const Comment = mongoose.model("Comment", commentSchema);

--- a/server/src/routes/comment.router.js
+++ b/server/src/routes/comment.router.js
@@ -63,6 +63,16 @@ commentRouter.post('/create-comment', authMiddleware, (req, res) => {
     })
 })
 
+/* This function is for commentRouter.delete("/:comment_id", authMiddleware, (req, res, next) api
+    It deletes the selected comment inside Comment and update the comment_ids field inside the Post.
+*/
+/*
+    // req body
+    let req_body = {
+      'post_id': this.props.post_id,
+      'group_id': this.props.group_id
+    };
+*/
 function update_comment_and_post(req,res){
     Comment.findByIdAndDelete(req.params.comment_id, (err, deleteComment) => {
         console.log("authentication check complete");

--- a/server/src/routes/comment.router.js
+++ b/server/src/routes/comment.router.js
@@ -4,6 +4,8 @@ const express = require('express');
 const commentRouter = express.Router();
 const Post = require('../models/post.model');
 const Comment = require('../models/comment.model');
+var  Group = require('../models/group.model');
+var Account =  require('../models/account.model');
 const authMiddleware = require('../middleware/auth');
 
 /* Make a comment on a post */
@@ -13,7 +15,8 @@ commentRouter.post('/create-comment', authMiddleware, (req, res) => {
         author: req.body.author,
         is_reply: req.body.is_reply,
         text: req.body.text,
-        created: Date.now()
+        created: Date.now(),
+        post_owner: req.body.post_owner
     };
 
     // create the comment, append it in the parent post's comments
@@ -60,4 +63,118 @@ commentRouter.post('/create-comment', authMiddleware, (req, res) => {
     })
 })
 
+
+/* Delete a comment on a post */
+/* Note, only the group superviser, post or comment owner can delete the comment*/ 
+/*
+    // req body
+    let req_body = {
+      'post_id': this.props.post_id,
+      'group_id': this.props.group_id
+    };
+*/
+commentRouter.delete("/:comment_id", authMiddleware, (req, res, next) => {
+    // make sure the user is the group superviser, post creater, or comment creater
+    req.authorized = 'false';
+    Group.findOne({_id: req.body.group_id}, function(groupFindErr, groupFind){
+        if(groupFindErr || !groupFind){
+            res.status(400).send({
+                success:false,
+                error: JSON.stringify(groupFindErr),
+                msg:"1"
+            });
+            return; 
+        }
+        else{
+            // check if the user is the group supervisor
+            if(req.user.user_info._id.equals(groupFind.supervisor_id)){
+                // delete the commend and update the post
+                req.authorized = 'true';
+            }
+            else{
+                // check whether the user is the post/comment owner
+                console.log('hello1');
+                console.log(req.params);
+                Comment.findById(req.params.comment_id, function(commentFindErr, commentFind){
+                    if(!commentFind || commentFindErr){
+                        req.authorized = 'error';
+                        res.status(400).send({
+                            success:false,
+                            error: JSON.stringify(commentFindErr)
+                        });
+                        return;
+                    }
+                    console.log(commentFind);
+                    if(commentFind.author === req.user.user_info.username){
+                        console.log("authorized as comment owner");
+                        req.authorized = 'true';
+                    }
+                    else if(commentFind.post_owner === req.user.user_info.username){
+                        console.log("authorized as post owner");
+                        req.authorized = 'true';
+                    }
+                    else{
+                        /* if the user is neither the group superviser, 
+                        post creater, nor comment creater*/ 
+                        res.status(403).send({
+                            success:false,
+                            error: "Sorry, you are not authorized to delete this post"
+                        });
+                    }
+                }).catch(function(commentFindErr){
+                    req.authorized = 'error';
+                    res.status(400).send({
+                        success:false,
+                        error: JSON.stringify(commentFindErr)
+                    });
+                });
+            }
+        }
+    })
+
+    Comment.findByIdAndDelete(req.params.comment_id, (err, deleteComment) => {
+        if (err) {
+            console.log("500 #1, fail to delete the comment", err);
+            return res.status(500).send({
+                success: false,
+                error: JSON.stringify(err)
+            });
+        }
+        else{
+            // update the post's comment_ids
+            var filter = {
+                '_id': req.body.post_id
+            },
+            update = {
+                $pull: {comment_ids: req.params.comment_id}
+            },
+            options = {
+                useFindAndModify: false
+            };
+            Post.findOneAndUpdate(filter, update, options, (postUpdateErr, updatedPost) => {
+                if(postUpdateErr){
+                    res.status(400).send({
+                        success:false,
+                        error: JSON.stringify(postUpdateErr)
+                    });
+                    return;
+                }
+                else if(!updatedPost){
+                    res.status(404).send({
+                        success:false,
+                        error: "Post not existed"
+                    });
+                    return;
+                }
+                else{
+                    return res.status(201).send({
+                        success: true,
+                        data: updatedPost,
+                        message: "Comment deleted successfully"
+                    })
+                }
+            })
+        }
+    })
+})
 module.exports = commentRouter;


### PR DESCRIPTION
Implement the api inside CommentRouter to delete a specific comment. 
The url is api/comments/:comment_id. The HTTP request is delete.
Only the group supervisor, post owner, and comment creater can delete the comment. Others will return 403
The api also checks whether the comment exists. If not, it returns a 400 error with msg "Current comment not found"

The comment.model.js is also modified to add the post_owner . 