### PR TITLE
Making requests, post/comment deletion technicalities, styling/ux improvements

### DIFF
--- a/client/src/Announcements.js
+++ b/client/src/Announcements.js
@@ -11,6 +11,7 @@ const Announcement = (props) => {
   const [alertVisible, setAlertVisible] = useState(true);
   const onDismiss = () => setAlertVisible(false);
   const [bodyIsOpen, setBodyIsOpen] = useState(false);
+  const [deleteConfirm, setDeleteConfirm] = useState(false);
   const bodyToggle = () => {
     console.log('Announcement', props.announcement)
     setBodyIsOpen(!bodyIsOpen);
@@ -50,7 +51,15 @@ const Announcement = (props) => {
             <AiFillCaretUp onClick={bodyToggle}/> : 
             <AiFillCaretDown onClick={bodyToggle}/>}
           {props.is_supervisor ? 
-          <Button onClick={()=>{deleteAnnouncement(props.announcement._id)}} 
+          deleteConfirm ?
+          <div>
+            <Button size="sm" outline color="danger"
+              onClick={()=>{deleteAnnouncement(props.announcement._id)}}>
+                Delete Announcement?</Button>
+            <Button size="sm" outline 
+              onClick={()=>{setDeleteConfirm(false)}}>Cancel</Button>
+          </div> 
+          :<Button onClick={()=>{setDeleteConfirm(true)}} 
             outline size="sm" color="link" 
             style={{padding:'0', color:"red"}}>
             Delete Announcement</Button> : null }
@@ -180,12 +189,14 @@ class CreateAnnouncement extends Component {
           <Form onSubmit={(e) => this.submitForm(e)}>
             <FormGroup>
               <Input 
-                type="text" name="title" id="title" placeholder="Title"
+                type="text" name="title" id="title" 
+                placeholder="Announcement Title"
                 onChange={(e) => { this.handleChange(e);}}/>
             </FormGroup>
             <FormGroup >
               <Input 
-                type="textarea" name="body" id="body" placeholder="Body" 
+                type="textarea" name="body" id="body" 
+                placeholder="Announcement Body" 
                 onChange={(e) => { this.handleChange(e);}}/>
             </FormGroup>
             <Button color="link" disabled={this.state.submit_loading} 

--- a/client/src/Comments.js
+++ b/client/src/Comments.js
@@ -1,16 +1,94 @@
-import React, { Component, useState, useEffect } from 'react';
-import { Alert, Button, Form, FormGroup, Input, ToastBody, Toast } from 'reactstrap';
+import React, {  Component, useState, useEffect } from 'react';
+import { Container, Alert, Button, Form, FormGroup, Input, 
+  Badge, ToastBody, Toast } from 'reactstrap';
 import authorizeUser from './Auth';
 import { connect } from 'react-redux'
 import './css/Comments.css'
+import { BsFillPersonFill } from "react-icons/bs";
+
 
 const Comment = (props) => {
+  const [showOptions, setShowOptions] = useState(false);
+  const [makingReply, setMakingReply] = useState(false);
+  const [deleteConfirm, setDeleteConfirm] = useState(false);
+  const makeReply = () => {
+    setShowOptions(false);
+    setMakingReply(true);
+    setDeleteConfirm(false);
+  }
+  const cancelReply = () => {
+    setShowOptions(true);
+    setMakingReply(false);
+  }
+  const deleteComment = (comment_id) => {
+    props.dispatch({ type: 'LOADING' });
+    let token = props.cookies.get('token');
+    let endpoint = '/comments/' + comment_id;
+    console.log('comment delete endpoint:', endpoint)
+    authorizeUser(token, endpoint, 
+      {group_id: props.group_id, 
+        post_id: props.post_id}, 'delete')
+      .then(result => {
+        console.log("result delete comment:",result)
+        if (result){
+          window.location.reload(false);
+        } else {
+          console.log('Error: no result on deleting comment.')
+          props.dispatch({ type: 'LOGOUT' });
+        }
+      })
+      .catch(error => {
+        console.log(error)
+        props.dispatch({ type: 'LOGOUT' });
+      })
+  }
+  
   return (
-    <Toast style={{'margin': '2%'}}>
-      <div style={{'margin': '2%'}}>
-        <strong>{props.comment.author}</strong>
-        <p>{props.comment.text}</p>
-      </div>
+    <Toast onMouseEnter={()=>{if(!makingReply) setShowOptions(true)}}
+      onMouseLeave={()=>{if(!makingReply) setShowOptions(false)}}>
+      <ToastBody style={{display:'flex',
+        paddingBottom: (showOptions ? '0' : '1em')}}>
+      
+      { props.is_comment_author ? 
+      <strong style={{color:'#3771DA'}}><BsFillPersonFill/></strong>: 
+      <strong style={{color:'#3771DA'}}>{props.comment.author}</strong>
+      }
+      {' '}
+      <Container className="themed-container" fluid="lg">
+        {props.comment.text}</Container>
+      
+      </ToastBody>
+      {makingReply ? 
+        <div style={{paddingLeft:'0.7em'}}>
+          <CreateComment 
+            username={props.username}
+            group_id={props.group_id}
+            cookies={props.cookies}
+            post_id={props.post_id}
+            post_owner={props.comment.post_owner}
+            is_reply={true}
+            author_replying_to={props.comment.author}/>
+            </div>: null }
+      {showOptions ? 
+      <Button onClick={makeReply}color="link" size="sm" 
+        style={{paddingLeft:'0.7em'}}>
+        Reply</Button> : (makingReply ? 
+        <Button onClick={cancelReply}color="link" size="sm" 
+        style={{paddingLeft:'0.7em'}}>
+          Cancel</Button>: null) }
+      {showOptions && 
+      (props.is_post_owner || props.is_supervisor || props.is_comment_author) ?
+      deleteConfirm ?
+      <div>
+        <Button size="sm" outline color="danger"
+          onClick={()=>{deleteComment(props.comment._id)}}>
+            Delete Comment?</Button>
+        <Button size="sm" outline 
+          onClick={()=>{setDeleteConfirm(false)}}>Cancel</Button>
+      </div> 
+      : <Button onClick={()=>{setDeleteConfirm(true)}} 
+      color="link" size="sm" style={{paddingLeft:'0.7em'}}>
+      Delete</Button>:null}
     </Toast>
   );
 }
@@ -50,7 +128,15 @@ const Comments = (props) => {
         { Object.keys(comments).map(function(key) {
           return (
             <div key={key}>
-              <Comment comment={comments[key]}/>
+              <Comment comment={comments[key]}
+                dispatch={props.dispatch}
+                cookies={props.cookies}
+                group_id={props.group_id}
+                post_id={props.post_id}
+                username={props.username}
+                is_post_owner={props.is_post_owner}
+                is_supervisor={props.is_supervisor}
+                is_comment_author={props.username === comments[key].author}/>
             </div>
           )
         }.bind(this))}
@@ -101,30 +187,35 @@ class CreateComment extends Component {
       'post_id': this.props.post_id,
       'post_owner': this.props.post_owner
     };
+    if (this.props.is_reply){
+      req_body.text = '@' + this.props.author_replying_to + ' ' + req_body.text
+    }
     let endpoint = '/comments/create-comment';
     let token = this.props.cookies.get('token');
 
     // make api request to create comment
     authorizeUser(token, endpoint, req_body).then(result => {
       console.log("result comment: ", result);
+      window.location.reload(false);
     }).catch(error => {
       console.log(error);
+      window.location.reload(false);
     });
   }
 
   render() {
     return (
       <div>
-        <Alert isOpen={this.state.commentBodyError} color="danger">
-          Comment cannot be empty!
-        </Alert>
         <Form onSubmit={this.submitForm}>
           <FormGroup>
-            <Input type="textarea" name="commentBody" id="commentBody" 
-              placeholder="Comment here"
+            <Input type="text" name="commentBody" id="commentBody" 
+              placeholder={this.props.is_reply ? "Reply" : "Comment here"}
               onChange={(e) => { this.handleChange(e); }} />
+              <Alert style={{padding:'0.7em'}}
+                isOpen={this.state.commentBodyError} color="danger">
+                Comment cannot be empty!
+              </Alert>
           </FormGroup>
-          <Button color="primary" size="sm">Comment</Button>
         </Form>
       </div>
     );
@@ -136,4 +227,4 @@ const mapStateToProps = (state) => ({
 });
 
 export default connect(mapStateToProps, null)(Comments);
-export { CreateComment, Comments };
+export { CreateComment };

--- a/client/src/Group.js
+++ b/client/src/Group.js
@@ -93,7 +93,14 @@ class Group extends Component {
               announcements={this.state.announcements}/>
             <h4>Posts</h4>
             <Row style={{paddingLeft:'1em'}}>
-            <CreatePost group_id={this.state.group_id}
+            <CreatePost 
+              is_request={false}
+              group_id={this.state.group_id}
+              username={this.props.user_info.username}
+              cookies={this.props.cookies}/>
+            <CreatePost 
+              is_request={true}
+              group_id={this.state.group_id}
               username={this.props.user_info.username}
               cookies={this.props.cookies}/>
             { this.props.user_info.is_supervisor ?
@@ -117,7 +124,8 @@ class Group extends Component {
 const mapStateToProps = (state) => ({
     logged_in: state.logged_in,
     user_info: state.user_info,
-    loading: state.loading
+    loading: state.loading,
+    refetch_page: state.refetch_page
 });
   
 export default withRouter(connect(mapStateToProps)(Group));

--- a/server/src/models/comment.model.js
+++ b/server/src/models/comment.model.js
@@ -25,7 +25,11 @@ const commentSchema = new mongoose.Schema({
     post_owner: {
         type: String,
         required: true
-   } 
+    },
+    parent_post_id: {
+        type: mongoose.ObjectId,
+        ref: "Post"
+    },
 });
 
 const Comment = mongoose.model("Comment", commentSchema);

--- a/server/src/models/post.model.js
+++ b/server/src/models/post.model.js
@@ -32,6 +32,11 @@ const postSchema = new mongoose.Schema({
   like_ids: [{
     type: String
   }],
+  is_request: {
+    type: Boolean,
+    required: true
+  },
+
 });
 
 const Post = mongoose.model("Post", postSchema);

--- a/server/src/routes/comment.router.js
+++ b/server/src/routes/comment.router.js
@@ -10,7 +10,7 @@ const authMiddleware = require('../middleware/auth');
 
 /* Get comments for a post given a post_id */
 commentRouter.get('/get-comments/:post_id', authMiddleware, (req, res) => {
-    console.log("GET COMMENT REQ: ", req);
+    //console.log("GET COMMENT REQ: ", req);
     // Find the post that contains our target comments
     Post.findById(req.params.post_id, (err, targetPost) => {
         if (err) {
@@ -51,7 +51,7 @@ commentRouter.get('/get-comments/:post_id', authMiddleware, (req, res) => {
 
 /* Make a comment on a post */
 commentRouter.post('/create-comment', authMiddleware, (req, res) => {
-    console.log("CREATE COMMENT REQ: ", req);
+    //console.log("CREATE COMMENT REQ: ", req);
     // TODO: check that user making req has proper permissions to comment on the specificed post
     let newComment = {
         author: req.body.author,
@@ -181,8 +181,8 @@ commentRouter.delete("/:comment_id", authMiddleware, (req, res, next) => {
             });
         }
         else{
-            console.log('hello1');
-            console.log(req.params);
+            //console.log('hello1');
+            //console.log(req.params);
             // first check whether the comment exists
             Comment.findById(req.params.comment_id, function(commentFindErr, commentFind){
                 if(!commentFind || commentFindErr){

--- a/server/src/routes/comment.router.js
+++ b/server/src/routes/comment.router.js
@@ -58,7 +58,8 @@ commentRouter.post('/create-comment', authMiddleware, (req, res) => {
         is_reply: req.body.is_reply,
         text: req.body.text,
         created: Date.now(),
-        post_owner: req.body.post_owner
+        post_owner: req.body.post_owner,
+        parent_post_id: req.body.post_id
     };
 
     // create the comment, append it in the parent post's comments

--- a/server/src/routes/post.router.js
+++ b/server/src/routes/post.router.js
@@ -4,6 +4,7 @@ const express = require('express');
 const postRouter = express.Router();
 const Post = require('../models/post.model'); // post model
 const Group = require('../models/group.model');
+const Comment = require('../models/comment.model');
 var Account = require('../models/account.model');
 var jwt_decode = require('jwt-decode');
 // test the authentication middleware
@@ -231,11 +232,22 @@ postRouter.delete("/", authMiddleware, (req, res, next) => {
                   success: false,
                   error: postDeleteErr
                 });
+                return;
               }
-              res.status(200).send({
-                success: true,
-                data: postDeleteResult,
-                message: "Post deleted successfully"
+              Comment.deleteMany({ parent_post_id: post_id }, 
+                function(commentErr, commentResult) {
+                if (commentErr) {
+                  res.status(400).send({
+                    success: false,
+                    error: commentErr
+                  });
+                } else {
+                  res.status(200).send({
+                    success: true,
+                    data: postDeleteResult,
+                    message: "Post deleted successfully"
+                  });
+                }
               });
             });
           }

--- a/server/src/routes/post.router.js
+++ b/server/src/routes/post.router.js
@@ -4,6 +4,8 @@ const express = require('express');
 const postRouter = express.Router();
 const Post = require('../models/post.model'); // post model
 const Group = require('../models/group.model');
+var Account = require('../models/account.model');
+var jwt_decode = require('jwt-decode');
 // test the authentication middleware
 const authMiddleware = require('../middleware/auth');
 
@@ -46,6 +48,7 @@ postRouter.post("/", authMiddleware, (req, res, next) => {
     title: req.body.title,
     body: req.body.body,
     author: req.body.author,
+    is_request: req.body.is_request,
     likes: 0,
     created: Date.now(),
   };
@@ -160,20 +163,87 @@ postRouter.patch("/:post_id", authMiddleware, (req, res, next) => {
 });
 
 /* Delete Single Post */
-postRouter.delete("/:post_id", authMiddleware, (req, res, next) => {
-  Post.findByIdAndDelete(req.params.post_id, function(err, result){
-      if(err){
-        res.status(400).send({
-          success: false,
-          error: err.message
+// Requires:
+// body : {
+//    post_id
+//    group_id
+// }
+postRouter.delete("/", authMiddleware, (req, res, next) => {
+  let post_id = req.body.post_id;
+  let group_id = req.body.group_id;
+  var decoded = jwt_decode(req.token);
+  var criteria = {username: decoded.username}
+  let fieldsToUpdate = { '$pull': { 'post_ids': post_id } }
+  let authorized_to_delete = false;
+
+  // Find account based on username
+  Account.findOne(criteria, function(accountErr, user){
+    if(accountErr || !user){
+      res.status(400).send({
+        success:false,
+        error: accountErr,
+      });
+      return;
+    // Successful so far
+    } else {
+
+      // User authorized to delete if supervisor
+      if (user.is_supervisor) authorized_to_delete = true;
+
+      Post.findById(post_id, function(postFindErr, postFindResult){
+        if(postFindErr || !postFindResult){
+          res.status(400).send({
+            success: false,
+            error: postFindErr
+          });
+          return;
+        } 
+        // Successful so far
+
+        // User authorized to delete if post owner
+        if (postFindResult.author == decoded.username) authorized_to_delete = true;
+        if (!authorized_to_delete){
+          res.status(401).send({
+            success: false,
+            error: "Unauthorized to delete."
+          });
+          return;
+        }
+        // Successful so far
+
+        // Find group by group_id to remove post_id from list of post_ids
+        Group.findByIdAndUpdate(group_id, fieldsToUpdate, 
+        { useFindAndModify: false },
+        function (groupErr, groupResult) {
+          if(groupErr || !groupResult){
+            res.status(400).send({
+              success: false,
+              error: groupErr
+            });
+            return;
+          }
+          // Successful so far
+          else {
+            Post.findByIdAndDelete(post_id, 
+              function(postDeleteErr, postDeleteResult){
+              if(postDeleteErr || !postDeleteResult){
+                res.status(400).send({
+                  success: false,
+                  error: postDeleteErr
+                });
+              }
+              res.status(200).send({
+                success: true,
+                data: postDeleteResult,
+                message: "Post deleted successfully"
+              });
+            });
+          }
         });
-      }
-    res.status(200).send({
-      success: true,
-      data: result,
-      message: "Post deleted successfully"
-    });
-  });
-});
+      });
+    }
+  })
+})
+
 
 module.exports = postRouter;


### PR DESCRIPTION
- Making requests as type of post

- Post deletion frontend + backend
   - DELETE `/api/posts/`

- Comment deletion frontend
   - Frontend only shows option to delete if supervisor, post owner or comment owner 

- Confirmation before deleting for posts, comments and announcements

- Hover over comment to see options to reply and delete (if possible)

- Basic comment replying working (backend still needs to be updated, which will also allow frontend to organize comments based on regular comment vs reply)

- Removed comment button for more space and cleaner, just press enter to comment

- Comment author area shows icon instead of username if created by user