### PR TITLE
Finish the api to verify admin when creating/joining a private group.…

### DIFF
--- a/server/src/models/account.model.js
+++ b/server/src/models/account.model.js
@@ -1,11 +1,23 @@
 // Mongoose schema that represents a user account.
 
 const mongoose = require('mongoose');
+const fileSchema = new mongoose.Schema({
+    file_urls:[{
+        type: String
+    }],
+    file_storage_type:{
+        type: String
+    }
+});
 const accountSchema = new mongoose.Schema({
    username: {
        type: String,
        required: true,
        unique: true
+   },
+   full_legal_name: {
+       type:String,
+       required:true
    },
    password: { // SHA-256 hashed, salted password
        type: String,
@@ -24,6 +36,16 @@ const accountSchema = new mongoose.Schema({
        type: Boolean,
        required: true
    },
+   requested_groups_ids:[{
+       type: String
+   }],
+   requested_groups_files:[{
+        requested_group_id:{
+            type: mongoose.ObjectId,
+            ref: "Group"
+        },
+        fileInfo:fileSchema
+   }],
    managed_groups_ids: [{
        type: mongoose.ObjectId,
        ref: "Group"

--- a/server/src/models/group.model.js
+++ b/server/src/models/group.model.js
@@ -7,6 +7,11 @@ const groupSchema = new mongoose.Schema({
         required: true,
         unique: true
     },
+    // Street address of the property
+    address:{
+        type: String,
+        required: true
+    },
     post_ids: [{
         type: mongoose.ObjectId,
         ref: "Post"
@@ -19,7 +24,8 @@ const groupSchema = new mongoose.Schema({
         type: Boolean,
         required: true
     },
-    is_valid : {
+    // whether the group_creation is approved
+    is_approve : {
         type: Boolean,
         required: true
     },

--- a/server/src/routes/signup.router.js
+++ b/server/src/routes/signup.router.js
@@ -10,6 +10,16 @@ const jwt = require('jsonwebtoken');
 const bcrypt = require('bcryptjs');
 
 /* Create a regular user account */
+/*
+  req.body ={
+    username: string
+    password: string 
+    email: string
+    group_ids: [ids of group models],
+    managed_group_ids: [ids of group models],
+    full_legal_name: string
+  }
+*/
 signUpRouter.post("/regular", (req, res, next) => {
     let newAccount = {
         username: req.body.username,
@@ -17,7 +27,10 @@ signUpRouter.post("/regular", (req, res, next) => {
 		    email: req.body.email,
         group_ids: req.body.group_ids,
         is_supervisor: 0,
-        managed_group_ids: req.body.managed_group_ids
+        managed_group_ids: req.body.managed_group_ids,
+        requested_groups_ids:[],
+        requested_groups_files:[],
+        full_legal_name: req.body.full_legal_name
       };
       
       bcrypt.genSalt(10,(err,salt) => {
@@ -87,6 +100,16 @@ signUpRouter.post("/regular", (req, res, next) => {
 });
 
 /* Create an admin user account */
+/*
+  req.body ={
+    username: string
+    password: string 
+    email: string
+    group_ids: [ids of group models],
+    managed_group_ids: [ids of group models],
+    full_legal_name: string
+  }
+*/
 signUpRouter.post("/admin", (req, res, next) => {
   bcrypt.genSalt(10,(err,salt) => {
     if(err){
@@ -110,7 +133,10 @@ signUpRouter.post("/admin", (req, res, next) => {
         email: req.body.email,
         group_ids: req.body.group_ids,
         is_supervisor: 1,
-        managed_group_ids: req.body.managed_group_ids
+        managed_group_ids: req.body.managed_group_ids,
+        requested_groups_ids:[],
+        requested_groups_files:[],
+        full_legal_name: req.body.full_legal_name
        }, function(err, result) {
         if(err){
           res.status(400).send({


### PR DESCRIPTION
1. Finish the api in group.router.js to verify the admin before creating/joining the group.  Verification files' links and types(Google, Dropbox...) are added into the admin's account for verification.
   POST /api/group/request?group_exists=string('false'/ 'true' ). 
   group_exist is designed as as string. Where 'false' means the group does not exist. 'true' or other strings mean the group exists, so the admin is just joining the existing group.

2. updated the account model for the api.  'full_legal_name', 'requested_groups_ids', 'requested_groups_files' fields are added. 'requested_groups_ids' is an array that takes group_id of groups that the user requested to create or join in. 

NOTE: requested_groups_files is an array of file object. For each object inside, it has requested_group_id as the reference key, fileInfo as the object to store the file_urls and file_storage_type. Since mongoose provides very limited support for dictionary, I end up using nested object.


3. update the group model to record the property's address by adding the 'address' field.  Boolean 'is_approve' is also added for the verification process.  When creating a group, is_approve will be set to false. It will be set to true if verification completed(The api to set it to true hasn't been implemented)
    
4. modify the signup router to take full_legal name of users.  The signup api will take full_legal_name of user as a required field. 
5. modify the original POST /api/group/create api to require the property's address (str) when creating a group.  For now when creating a group, the user will be required to provide the property's address as string field 'address'. 