### PR TITLE
Completed the 3 apis for notifications and for regular users to make request to join a group

### DIFF
--- a/server/src/models/account.model.js
+++ b/server/src/models/account.model.js
@@ -54,6 +54,10 @@ const accountSchema = new mongoose.Schema({
    invited_groups_ids: [{
        type: mongoose.ObjectId,
        ref: "Group"
+   }],
+   requested_to_join_groups_ids: [{
+        type: mongoose.ObjectId,
+        ref: "Group"
    }]
 });
 

--- a/server/src/models/group.model.js
+++ b/server/src/models/group.model.js
@@ -44,6 +44,10 @@ const groupSchema = new mongoose.Schema({
     announcement_ids: [{
         type: mongoose.ObjectId,
         ref: "Announcement"
+    }],
+    requested_to_join_user_ids:[{
+        type: mongoose.ObjectId,
+        ref: "Account"
     }]
 });
 


### PR DESCRIPTION
1.Implemented the api for regular user to make request to join a private group.
    /api/group/user_request/:group_id
2. Implemented the api for group admins/co-admins to approve/deny a user's request to join the group
   approve: /api/group/accept_user_request/:group_id
   deny: /api/group/deny_user_request/:group_id
   The user_id is passed in the req.body.
3. Updated the account.model and group.model for the 3 apis
   For group model:   add requested_to_join_user_ids
   For account model:  add requested_to_join_groups_ids

