### PR TITLE
Group Search, Register Improvement

### DIFF
--- a/client/src/Home.js
+++ b/client/src/Home.js
@@ -58,6 +58,7 @@ class Home extends Component {
       return (<Loading />);
     }
     else {
+
       return (
       <div style={{padding:'2em'}}>
       <Jumbotron style={{minHeight:'27em', paddingTop:'0', 
@@ -95,7 +96,11 @@ class Home extends Component {
               is_supervisor={this.props.user_info.is_supervisor}
               token={this.props.cookies.get('token')}
               group_ids={this.props.user_info.group_ids.concat(
-                this.props.user_info.managed_groups_ids)}/> 
+                this.props.user_info.managed_groups_ids)}
+              requested_to_join_groups_ids=
+                {this.props.user_info.requested_to_join_groups_ids}
+              invited_groups_ids=
+                {this.props.user_info.invited_groups_ids}/> 
           </div>
         </Col>
         </Collapse>

--- a/client/src/Register.js
+++ b/client/src/Register.js
@@ -19,6 +19,7 @@ class Register extends Component {
     super(props);
     this.state = {
       email: "",
+      full_legal_name: "",
       username: "",
       password: "",
       password2: "",
@@ -129,6 +130,7 @@ class Register extends Component {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           "username": this.state.username,
+          "full_legal_name": this.state.full_legal_name,
           "password": this.state.password,
           "email": this.state.email,
           "is_supervisor": is_supervisor
@@ -189,7 +191,7 @@ class Register extends Component {
       });
   }
   render() {
-    const { email, username, password } = this.state;
+    const { email, username, full_legal_name, password } = this.state;
     if (this.props.logged_in){
       return (<Redirect to="/groups" />);
     }
@@ -207,7 +209,6 @@ class Register extends Component {
               <Input
                 type="email"
                 name="email"
-                id="exampleEmail"
                 placeholder="Email Address"
                 value={email}
                 valid={this.state.validate.emailState === "has-success"}
@@ -224,9 +225,21 @@ class Register extends Component {
           <Col>
             <FormGroup>
               <Input
+                type="text"
+                name="full_legal_name"
+                placeholder="Full Legal Name"
+                value={full_legal_name}
+                onChange={(e) => {
+                  this.handleChange(e);
+                }}
+              />
+            </FormGroup>
+          </Col>
+          <Col>
+            <FormGroup>
+              <Input
                 type="username"
                 name="username"
-                id="exampleUsername"
                 placeholder="Username"
                 value={username}
                 valid={this.state.validate.usernameState === "has-success"}
@@ -245,7 +258,6 @@ class Register extends Component {
               <Input
                 type={this.state.showPass ? "text" : "password"}
                 name="password"
-                id="examplePassword"
                 placeholder="Password"
                 value={password}
                 valid={this.state.validate.passState === "has-success"}

--- a/client/src/components/GroupSearch.js
+++ b/client/src/components/GroupSearch.js
@@ -118,7 +118,11 @@ class GroupSearch extends Component {
           <Button color="light" size="sm"
             onMouseEnter={()=>{
               this.setState({max_results: this.state.max_results + 10})
-            }}>See More</Button>
+            }}
+            onClick={()=>{
+              this.setState({max_results: this.state.max_results + 10})
+            }}
+            >See More</Button>
         </div> }
         </Col>
 

--- a/client/src/components/GroupSearch.js
+++ b/client/src/components/GroupSearch.js
@@ -40,6 +40,7 @@ class GroupSearch extends Component {
       show_results: true,
       results: [],
       result_group: 0,
+      max_results: 10
 
     }
     this.handleClickOutside = this.handleClickOutside.bind(this);
@@ -56,12 +57,12 @@ class GroupSearch extends Component {
   handleClickOutside = event => {
     const domNode = ReactDOM.findDOMNode(this);
     if (!domNode || !domNode.contains(event.target)) {
-      this.setState({ show_results: false })
+      this.setState({ show_results: false, max_results: 10 })
     }
   }
   handleChange = async (event) => {
     if (event.target.value === '') {
-      this.setState({ results: [] })
+      this.setState({ results: [], max_results: 10 })
       return;
     } 
     this.setState({ search: event.target.value })
@@ -70,7 +71,7 @@ class GroupSearch extends Component {
       .then(result => {
         console.log("result:",result)
         if (result){
-          this.setState({ results: result.data.results })
+          this.setState({ results: result.data.results, max_results: 10 })
         }
       })
       .catch(error => {
@@ -97,14 +98,28 @@ class GroupSearch extends Component {
         </Fade>
         { this.state.show_results ? 
           Object.keys(this.state.results).map(function(key) {
-          return (
-            <Result key={key} group={this.state.results[key]}
-              is_supervisor={this.props.is_supervisor}
-              joined={this.props.group_ids.indexOf(this.state.results[key]._id)
-              !== -1  ? true : false}/>
-          );
-        }.bind(this)) : null}
+            return (
+              key < (this.state.max_results - 1) ?
+              <div style={{paddingBottom: 
+                key.toString() === (this.state.results.length - 1).toString()
+                 ? '4em' : '0'}}>
+               
+              <Result key={key} group={this.state.results[key]}
+                joined={this.props.group_ids.indexOf(this.state.results[key]._id)
+                  !== -1 ? true : false}/>
+                  
+              </div> : null 
+            );
+          }.bind(this)) : null}
 
+        {!this.state.show_results || 
+        (this.state.max_results > this.state.results.length) ? null :
+        <div style={{display:'flex', justifyContent:'center', paddingBottom: '4em'}}>
+          <Button color="light" size="sm"
+            onMouseEnter={()=>{
+              this.setState({max_results: this.state.max_results + 10})
+            }}>See More</Button>
+        </div> }
         </Col>
 
         </div>

--- a/client/src/components/GroupSearch.js
+++ b/client/src/components/GroupSearch.js
@@ -105,6 +105,7 @@ class GroupSearch extends Component {
                  ? '4em' : '0'}}>
                
               <Result key={key} group={this.state.results[key]}
+                is_supervisor={this.props.is_supervisor}
                 joined={this.props.group_ids.indexOf(this.state.results[key]._id)
                   !== -1 ? true : false}/>
                   

--- a/client/src/components/GroupSearch.js
+++ b/client/src/components/GroupSearch.js
@@ -23,7 +23,14 @@ const Result = props => {
           : props.is_supervisor ?
           <Button  
           size="sm" color="warning">Must join as Regular User</Button>
-          :<Button size="sm" color="danger">Request to Join</Button>}
+          : props.requested ? 
+          <Button disabled
+          size="sm" color="warning">Requested</Button>
+          : props.invited ? 
+          <Button
+          size="sm" color="success">Invited! Join</Button>
+          :
+          <Button size="sm" color="danger">Request to Join</Button>}
           </Col>
         </Row>
         </ToastHeader>
@@ -100,14 +107,20 @@ class GroupSearch extends Component {
           Object.keys(this.state.results).map(function(key) {
             return (
               key < (this.state.max_results - 1) ?
-              <div style={{paddingBottom: 
+              <div key={key} style={{paddingBottom: 
                 key.toString() === (this.state.results.length - 1).toString()
-                 ? '4em' : '0'}}>
+                 ? '6em' : '0'}}>
                
-              <Result key={key} group={this.state.results[key]}
+              <Result  group={this.state.results[key]}
                 is_supervisor={this.props.is_supervisor}
                 joined={this.props.group_ids.indexOf(this.state.results[key]._id)
-                  !== -1 ? true : false}/>
+                  !== -1 ? true : false}
+                requested=
+                {this.props.requested_to_join_groups_ids.indexOf(
+                  this.state.results[key]._id) !== -1 ? true : false}
+                invited=
+                {this.props.invited_groups_ids.indexOf(
+                  this.state.results[key]._id) !== -1 ? true : false}/>
                   
               </div> : null 
             );
@@ -115,7 +128,8 @@ class GroupSearch extends Component {
 
         {!this.state.show_results || 
         (this.state.max_results > this.state.results.length) ? null :
-        <div style={{display:'flex', justifyContent:'center', paddingBottom: '4em'}}>
+        <div style={{display:'flex', justifyContent:'center', 
+          paddingTop:'0.5em', paddingBottom: '4em'}}>
           <Button color="light" size="sm"
             onMouseEnter={()=>{
               this.setState({max_results: this.state.max_results + 10})
@@ -123,7 +137,7 @@ class GroupSearch extends Component {
             onClick={()=>{
               this.setState({max_results: this.state.max_results + 10})
             }}
-            >See More</Button>
+            >See More...</Button>
         </div> }
         </Col>
 

--- a/server/src/routes/helper.js
+++ b/server/src/routes/helper.js
@@ -1,15 +1,32 @@
 exports.addGroupIDS = function(user, decoded_jwt){
   let group_ids = [];
   let managed_groups_ids = [];
+  let requested_groups_ids = [];
+  let invited_groups_ids = [];
+  let requested_to_join_groups_ids = [];
+
   if ('group_ids' in user){ 
     group_ids = user.group_ids; 
   }
   if ('managed_groups_ids' in user){
     managed_groups_ids = user.managed_groups_ids; 
   }
+  if ('requested_groups_ids' in user){
+    requested_groups_ids = user.requested_groups_ids; 
+  }
+  if ('invited_groups_ids' in user){
+    invited_groups_ids = user.invited_groups_ids; 
+  } 
+  if ('requested_to_join_groups_ids' in user){
+    requested_to_join_groups_ids = user.requested_to_join_groups_ids; 
+  } 
+  
   let full = Object.assign(decoded_jwt, {
     group_ids: group_ids,
-    managed_groups_ids: managed_groups_ids
+    managed_groups_ids: managed_groups_ids,
+    requested_groups_ids: requested_groups_ids,
+    invited_groups_ids: invited_groups_ids,
+    requested_to_join_groups_ids: requested_to_join_groups_ids
   })
   return full;
 }

--- a/server/src/routes/signup.router.js
+++ b/server/src/routes/signup.router.js
@@ -30,6 +30,8 @@ signUpRouter.post("/regular", (req, res, next) => {
         managed_group_ids: req.body.managed_group_ids,
         requested_groups_ids:[],
         requested_groups_files:[],
+        requested_to_join_groups_ids: [],
+        invited_user_ids: [],
         full_legal_name: req.body.full_legal_name
       };
       
@@ -136,6 +138,8 @@ signUpRouter.post("/admin", (req, res, next) => {
         managed_group_ids: req.body.managed_group_ids,
         requested_groups_ids:[],
         requested_groups_files:[],
+        requested_to_join_groups_ids: [],
+        invited_user_ids: [],
         full_legal_name: req.body.full_legal_name
        }, function(err, result) {
         if(err){


### PR DESCRIPTION
- Group Search
    - Don't load all results at once, hover over (or click/touch for mobile) see more button to keep loading more
    - Detects which groups user has requested to join or been invited to or already joined (no functionality yet though)
    - Supervisors cannot join regularly as they can only create/manage their own groups
- Register
    - Full legal name required
    - requested_to_join_groups_ids initialized
    - invited_groups_ids initialized
- helper.js
    - added user's group lists to be returned so redux user_info object can have it for usage in group search