### PR TITLE
Fixed and Tested the cosupervisor bug inside comment.router.js

### DIFF
--- a/server/src/routes/comment.router.js
+++ b/server/src/routes/comment.router.js
@@ -199,7 +199,7 @@ commentRouter.delete("/:comment_id", authMiddleware, (req, res, next) => {
                  // check if the user is the group supervisor
                  // check managed_groups ids/ is_supervior -> Account
                 else if(req.user.user_info.is_supervisor === true && 
-                 req.user.user_info.managed_groups_ids.indexOf(groupFind._id) != -1) {
+                 req.user.user_info.managed_groups_ids.indexOf(groupFind._id) !== -1) {
                     // delete the commend and update the post
                     console.log("authorized as group supervisor");
                     update_comment_and_post(req,res);

--- a/server/src/routes/comment.router.js
+++ b/server/src/routes/comment.router.js
@@ -197,7 +197,9 @@ commentRouter.delete("/:comment_id", authMiddleware, (req, res, next) => {
                 }
                 // check whether the user is authorized to delete the post
                  // check if the user is the group supervisor
-                else if(req.user.user_info._id.equals(groupFind.supervisor_id)){
+                 // check managed_groups ids/ is_supervior -> Account
+                else if(req.user.user_info.is_supervisor === true && 
+                 req.user.user_info.managed_groups_ids.indexOf(groupFind._id) != -1) {
                     // delete the commend and update the post
                     console.log("authorized as group supervisor");
                     update_comment_and_post(req,res);

--- a/server/src/routes/group.router.js
+++ b/server/src/routes/group.router.js
@@ -41,6 +41,7 @@ groupRouter.get('/query', authMiddleware, (req, res, next) => {
     group_id: string,
     user_id: string (user of admin requesting)
   }
+  check if the user_id is supervisor if front-end doesn't check.
 */
 groupRouter.post("/approve", authMiddleware,(req, res) => {
   let group_id = req.body.group_id;


### PR DESCRIPTION
Fixed the bug that cosupervisors couldn't delete comments inside the private-group forum.  By modifying the comment.router.js in server side, now cosupervisors of the private group can delete comments of other users

Also added comments for possible future fixes in group.router.js.



