### PR TITLE
Add the apis for admins to add/delete tags for their managed group

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -19,6 +19,7 @@ const devRouter = require('./src/routes/dev.router');
 const announcementRouter = require('./src/routes/announcement.router');
 const notificationRouter = require('./src/routes/notification.router');
 const userRouter = require('./src/routes/user.router');
+const tagRouter = require('./src/routes/tag.router');
 
 const SESSION_DURATION = 1000 * 60 * 60// 1 hour
 
@@ -46,6 +47,7 @@ app.use('/api/account', accountRouter);
 app.use('/api/authorize',authRouter);
 app.use('/api/group', groupRouter);
 app.use('/api/dev', devRouter);
+app.use('/api/tag', tagRouter);
 
 // listen
 app.listen(PORT, function () {

--- a/server/src/models/group.model.js
+++ b/server/src/models/group.model.js
@@ -1,6 +1,24 @@
 // Mongoose schema that represents a group.
 
 const mongoose = require('mongoose');
+/*
+const tag_name = new mongoose.Schema({
+    tag_name:{
+        type: String,
+        required: true,
+        unique: true
+    }
+});
+*/
+const post_info = new mongoose.Schema({
+    _id : false,
+    post_id:{
+        type: mongoose.ObjectId,
+        ref: "Post",
+        required:true
+    }
+});
+
 const groupSchema = new mongoose.Schema({
     group_name: {
         type: String,
@@ -48,7 +66,25 @@ const groupSchema = new mongoose.Schema({
     requested_to_join_user_ids:[{
         type: mongoose.ObjectId,
         ref: "Account"
+    }],
+    tags:[{
+        _id : false,
+        key:{
+            type: String,
+            required: true,
+            unique: true
+        },
+        post_ids:[post_info]
     }]
+    /*
+    tags:[{
+        key:tag_name,
+        post_ids:[{
+            type: mongoose.ObjectId,
+            ref: "Post"
+        }]
+    }]
+    */
 });
 
 const Group = mongoose.model("Group", groupSchema);

--- a/server/src/models/post.model.js
+++ b/server/src/models/post.model.js
@@ -1,6 +1,16 @@
 // Mongoose schema that represents a Post.
 
 const mongoose = require('mongoose');
+const tag_info = new mongoose.Schema({
+  _id:false,
+  tag_name:{
+      type: String
+  },
+  // user name of the tag author
+  author:{
+      type: String
+  }
+});
 const postSchema = new mongoose.Schema({
   title: {
     type: String,
@@ -53,7 +63,8 @@ const postSchema = new mongoose.Schema({
   },
   request_status: {
     type: String
-  } 
+  },
+  tags_info:[tag_info]
 });
 
 const Post = mongoose.model("Post", postSchema);

--- a/server/src/routes/group.router.js
+++ b/server/src/routes/group.router.js
@@ -1124,26 +1124,4 @@ groupRouter.patch("/deny_user_request/:group_id", authMiddleware, (req, res, nex
     });
   }
 });
-// set the denied field to true.
-
-/* add new apis
-// combined api for user_request and join
-
-// delete from requested_to_join_groups_ids, add to groups_ids in account.model
-// delete from requested_to_join_user_ids add to user_ids in group.model
-// send notification
-groupRouter.patch("/accept_user_request/:group_id", authMiddleware, (req, res, next)
-
-// delete from requested_to_join_groups_ids, delete from requested_to_join_user_ids
-// send notification
-groupRouter.patch("/deny_user_request/:group_id", authMiddleware, (req, res, next)
-// set the denied field to true.
-
-/*
-  For the notification system:
-  admin: user's join group request, user is accepted/rejected for request (creating group approved)
-  user: get invited to join a group, admin's responce for joining group request
-
-  // new comment for post????
-*/
 module.exports = groupRouter;

--- a/server/src/routes/tag.router.js
+++ b/server/src/routes/tag.router.js
@@ -172,8 +172,219 @@ tagRouter.patch("/delete",authMiddleware,(req,res,next) => {
         }
     })
 })
-/*User add a tag to a post*/
 
-/*Group admin or tag author deletes a tag to post*/
+/*
+    Update the db of Post and Group for user to add/delete a post's tag.
+*/
+function UpdateGroupandPost(req, res, group_fields_to_update, post_fields_to_update){
+    Group.findByIdAndUpdate(req.body.group_id,
+        group_fields_to_update, { useFindAndModify: false },
+        function (groupUpdateErr, groupUpdateResult) {
+            if(groupUpdateErr || !groupUpdateResult){
+                res.status(400).send({
+                  success:false,
+                  error: 'Update group failed',
+                });
+                return;
+            } 
+            else{
+                Post.findByIdAndUpdate(req.body.post_id,
+                    post_fields_to_update, { useFindAndModify: false },
+                    function (postUpdateErr, postUpdateResult) {
+                        if(postUpdateErr || !postUpdateResult){
+                            res.status(400).send({
+                              success:false,
+                              error: 'Update post failed',
+                            });
+                            return;
+                        } 
+                        else{
+                            res.status(200).send({
+                                success: true,
+                                message: "Tag added/deleted successfully."
+                            });
+                        }
+                })
+            }
+    })
+}
 
+/*User add a tag to a post
+    req.body:{
+        post_id: mongoose.ObjectId of "post"
+        group_id: mongoose.ObjectId of "group"
+        tag_name: string
+    }
+*/
+tagRouter.patch("/add_to_post",authMiddleware,(req,res,next) => {
+    // check required post_id, group_id, tag_name
+    if(!req.body.post_id){
+        res.status(400).send({
+            success:false,
+            error:"Please enter the post_id."
+        });
+        return;
+    }
+    if(!req.body.group_id){
+        res.status(400).send({
+            success:false,
+            error:"Please enter the group_id."
+        });
+        return;
+    }
+    if(!req.body.tag_name){
+        res.status(400).send({
+            success:false,
+            error:"Please enter the tag_name."
+        });
+        return;
+    }
+    var decoded = jwt_decode(req.token);
+    var criteria ={_id:req.body.post_id};
+    Post.findOne(criteria, function(postFindErr, postFind){
+        if(postFindErr || !postFind){
+            res.status(400).send({
+                success:false,
+                error: 'The post does not exist',
+            });
+            return;
+        }
+        // check whether the tag has been added to the post
+        else if(postFind.tags_info.findIndex(i => i.tag_name === req.body.tag_name) !== -1){
+            res.status(400).send({
+                success:false,
+                error: 'The tag has been added to the post.',
+              });
+            return;
+        }
+        else{
+            var group_info ={_id:req.body.group_id};
+            Group.findOne(group_info, function(groupFindErr, groupFind){
+                if(groupFindErr || !groupFind){
+                    res.status(400).send({
+                      success:false,
+                      error: 'The group does not exist',
+                    });
+                    return;
+                }
+                // check whether the tag exists in the group
+                else if(groupFind.tags.findIndex(i => i.key === req.body.tag_name) === -1){
+                    res.status(400).send({
+                        success:false,
+                        error: 'The group does not have this tag',
+                    });
+                    return;
+                }
+                // update both the post and group
+                else{
+                    var tag_index = groupFind.tags.findIndex(i => i.key === req.body.tag_name)
+                    var new_tags = groupFind.tags
+                    new_tags[tag_index]['post_ids'].push({"post_id":req.body.post_id})
+                    var group_fields_to_update = {'$set':{"tags":new_tags}}
+                    var tag_info ={"tag_name":req.body.tag_name,"author":decoded.username}
+                    var post_fields_to_update ={'$push':{"tags_info":tag_info}}
+                    //{'$pull': {"tags" : {"key":req.body.tag_name}}};
+                    UpdateGroupandPost(req,res,group_fields_to_update,post_fields_to_update)
+                }
+            })
+        }
+    })
+    
+})
+
+/*Group admin or tag author deletes a post's tag 
+   req.body:{
+        post_id: mongoose.ObjectId of "post"
+        group_id: mongoose.ObjectId of "group"
+        tag_name: string
+   }
+
+*/
+tagRouter.patch("/delete_from_post",authMiddleware,(req,res,next) => {
+    if(!req.body.post_id){
+        res.status(400).send({
+            success:false,
+            error:"Please enter the post_id."
+        });
+        return;
+    }
+    if(!req.body.group_id){
+        res.status(400).send({
+            success:false,
+            error:"Please enter the group_id."
+        });
+        return;
+    }
+    if(!req.body.tag_name){
+        res.status(400).send({
+            success:false,
+            error:"Please enter the tag_name."
+        });
+        return;
+    }
+    var decoded = jwt_decode(req.token);
+    var user_id = req.user.user_info._id;
+    var criteria ={_id:req.body.post_id};
+    Post.findOne(criteria, function(postFindErr, postFind){
+        if(postFindErr || !postFind){
+            res.status(400).send({
+                success:false,
+                error: 'The post does not exist',
+            });
+            return;
+        }
+        // check whether the tag has been added to the post
+        else if(postFind.tags_info.findIndex(i => i.tag_name === req.body.tag_name) === -1){
+            res.status(400).send({
+                success:false,
+                error: 'The post does not have the tag. Delete Failed',
+              });
+            return;
+        }
+        else{
+            var group_info ={_id:req.body.group_id};
+            var post_index = postFind.tags_info.findIndex(i => i.tag_name === req.body.tag_name)
+            var tag_author = postFind.tags_info[post_index]["author"]
+            Group.findOne(group_info, function(groupFindErr, groupFind){
+                if(groupFindErr || !groupFind){
+                    res.status(400).send({
+                      success:false,
+                      error: 'The group does not exist',
+                    });
+                    return;
+                }
+                // check whether the tag exists in the group
+                else if(groupFind.tags.findIndex(i => i.key === req.body.tag_name) === -1){
+                    res.status(400).send({
+                        success:false,
+                        error: 'The group does not have this tag',
+                    });
+                    return;
+                }
+                // check whether the user is the tag author or group admin
+                // otherwise, they are not authorized to delete the tag
+                else if(tag_author !== decoded.username &&
+                    groupFind.supervisor_id.toString() !== user_id.toString() &&
+                    groupFind.cosupervisor_ids.indexOf(user_id.toString()) === -1){
+                        res.status(401).send({
+                            success:false,
+                            error: 'Sorry, you are not authorized to delete this tag',
+                        });
+                        return;
+                }
+                else{
+                    // update both the post and group
+                    var tag_index = groupFind.tags.findIndex(i => i.key === req.body.tag_name)
+                    var new_tags = groupFind.tags
+                    var post_index = new_tags[tag_index]['post_ids'].indexOf({"post_id":req.body.post_id})
+                    new_tags[tag_index]['post_ids'].splice(post_index,1)
+                    var group_fields_to_update = {'$set':{"tags":new_tags}}
+                    var post_fields_to_update ={'$pull':{"tags_info":{"tag_name":req.body.tag_name}}}
+                    //{'$pull': {"tags" : {"key":req.body.tag_name}}};
+                    UpdateGroupandPost(req,res,group_fields_to_update,post_fields_to_update)
+                }
+            })
+        }
+    })
+})
 module.exports = tagRouter;

--- a/server/src/routes/tag.router.js
+++ b/server/src/routes/tag.router.js
@@ -1,0 +1,179 @@
+const express  = require('express');
+const authMiddleware = require('../middleware/auth');
+const tagRouter = express.Router();
+const Post = require('../models/post.model'); 
+const Group = require('../models/group.model');
+var Account =  require('../models/account.model');
+var jwt_decode = require('jwt-decode');
+
+/*Group admin add a tag to the group
+    req.body:{
+        group_id: mongoose.ObjectId of "Group"
+        tag_name: string
+    }
+*/ 
+tagRouter.patch("/add",authMiddleware,(req,res,next) => {
+    if(!req.body.group_id){
+        res.status(400).send({
+            success:false,
+            error:"Please enter the group_id."
+        });
+        return;
+    }
+    if(!req.body.tag_name){
+        res.status(400).send({
+            success:false,
+            error:"Please enter the tag_name."
+        });
+        return;
+    }
+    var decoded = jwt_decode(req.token);
+    var user_info = {username: decoded.username}
+    Account.findOne(user_info, function(accountErr, user){
+        if(accountErr || !user){
+          res.status(400).send({
+            success:false,
+            error: 'The account does not exist',
+          });
+          return;
+        } else {
+            var criteria ={_id:req.body.group_id};
+            Group.findOne(criteria, function(groupFindErr, groupFind){
+                if(groupFindErr || !groupFind){
+                  res.status(400).send({
+                    success:false,
+                    error: 'The group does not exist',
+                  });
+                  return;
+                } 
+                // check whether the user is the group_supervisor
+                else if(user.managed_groups_ids.indexOf(groupFind._id) === -1){
+                    return res.status(403).send({
+                        success:false,
+                        error: "Sorry, you are not authorized to create the tag"
+                    });
+                }
+                // check whether the tag has been created
+                else if(groupFind.tags.findIndex(i => i.key === req.body.tag_name) !== -1){
+                    res.status(400).send({
+                        success:false,
+                        error: 'The tag has been created',
+                    });
+                    return;
+                }
+                else {
+                    var new_tag ={
+                        key:req.body.tag_name,
+                        post_ids:[]
+                    }
+                    var fieldsToUpdate = {'$push': {tags: new_tag}};
+                    Group.findByIdAndUpdate(req.body.group_id,
+                    fieldsToUpdate, { useFindAndModify: false },
+                    function (groupUpdateErr, groupUpdateResult) {
+                        if(groupUpdateErr || !groupUpdateResult){
+                            res.status(400).send({
+                              success:false,
+                              error: 'Update group failed',
+                            });
+                            return;
+                        } 
+                        else{
+                            res.status(201).send({
+                                success: true,
+                                message: "Tag created successfully"
+                            });
+                        }
+                    })
+                }
+            })
+        }
+    })
+})
+/*Group admin delete a tag in the group
+    req.body:{
+        group_id: mongoose.ObjectId of "Group"
+        tag_name: string
+    }
+*/
+tagRouter.patch("/delete",authMiddleware,(req,res,next) => {
+    if(!req.body.group_id){
+        res.status(400).send({
+            success:false,
+            error:"Please enter the group_id."
+        });
+        return;
+    }
+    if(!req.body.tag_name){
+        res.status(400).send({
+            success:false,
+            error:"Please enter the tag_name."
+        });
+        return;
+    }
+    var decoded = jwt_decode(req.token);
+    var user_info = {username: decoded.username}
+    Account.findOne(user_info, function(accountErr, user){
+        if(accountErr || !user){
+          res.status(400).send({
+            success:false,
+            error: 'The account does not exist',
+          });
+          return;
+        } else {
+            var criteria ={_id:req.body.group_id};
+            Group.findOne(criteria, function(groupFindErr, groupFind){
+                if(groupFindErr || !groupFind){
+                  res.status(400).send({
+                    success:false,
+                    error: 'The group does not exist',
+                  });
+                  return;
+                } 
+                // check whether the user is the group_supervisor
+                else if(user.managed_groups_ids.indexOf(groupFind._id) === -1){
+                    return res.status(403).send({
+                        success:false,
+                        error: "Sorry, you are not authorized to delete the tag"
+                    });
+                }
+                // check whether the tag exists
+                else if(groupFind.tags.findIndex(i => i.key === req.body.tag_name) === -1){
+                    res.status(400).send({
+                        success:false,
+                        error: 'The tag does not exist',
+                    });
+                    return;
+                }
+                else {
+                    var deleted_tag ={
+                        key:req.body.tag_name
+                    }
+                    var fieldsToUpdate = {'$pull': {"tags" : {"key":req.body.tag_name}}};
+                    // delete the tag from the group
+                    Group.findByIdAndUpdate(req.body.group_id,
+                    fieldsToUpdate, { useFindAndModify: false },
+                    function (groupUpdateErr, groupUpdateResult) {
+                        if(groupUpdateErr || !groupUpdateResult){
+                            res.status(400).send({
+                              success:false,
+                              error: 'Update group failed',
+                            });
+                            return;
+                        } 
+                        else{
+                            res.status(200).send({
+                                success: true,
+                                message: "Tag deleted successfully"
+                            });
+                        }
+                    })
+                }
+            })
+        }
+    })
+})
+/*User add a tag to a post*/
+
+/*Group admin or tag author deletes a tag to post*/
+
+module.exports = tagRouter;


### PR DESCRIPTION
Implement the api for group admins to create/ delete a specific tag for one of their managed group.  The checks for 1. duplicate tags for creating 2. non-existing tags for deleting are implemented and tested. tag.router.js are created to house these new apis

group.model.js are changed to house the tag info for each group.

Delete some unused comments in group.router.js

Will make another pr tonight or before tomorrow's meeting for users(admin+regular users) to add/delete tags to a specific post

