### PR TITLE
Implement the api for user to add a review to a request. The review w…

### DIFF
--- a/server/src/models/account.model.js
+++ b/server/src/models/account.model.js
@@ -76,7 +76,10 @@ const accountSchema = new mongoose.Schema({
             type: String,
             required:true
         }
-   }]
+   }],
+   total_points:{
+    type: Number
+   }
 });
 
 const Account = mongoose.model("Account", accountSchema);

--- a/server/src/models/group.model.js
+++ b/server/src/models/group.model.js
@@ -75,16 +75,15 @@ const groupSchema = new mongoose.Schema({
             unique: true
         },
         post_ids:[post_info]
+    }],
+    completed_reviews:[{
+        type: mongoose.ObjectId,
+        ref: "Review"
+    }],
+    pending_reviews:[{
+        type: mongoose.ObjectId,
+        ref: "Review"
     }]
-    /*
-    tags:[{
-        key:tag_name,
-        post_ids:[{
-            type: mongoose.ObjectId,
-            ref: "Post"
-        }]
-    }]
-    */
 });
 
 const Group = mongoose.model("Group", groupSchema);

--- a/server/src/models/review.model.js
+++ b/server/src/models/review.model.js
@@ -1,0 +1,37 @@
+// Mongoose schema that represents a user account.
+const mongoose = require('mongoose');
+
+const reviewSchema = new mongoose.Schema({
+    post_id:{
+        type: mongoose.ObjectId,
+        ref: "Post",
+        required:true
+    },
+    group_id:{
+        type: mongoose.ObjectId,
+        ref: "Group",
+        required:true
+    },
+    requester:{
+        type: mongoose.ObjectId,
+        ref: "Account",
+        required:true
+    },
+    resolvers_ids: [{
+        type: mongoose.ObjectId,
+        ref: "Account"
+    }],
+    resolvers_usernames:[{
+        type: String
+    }],
+    ratings:[{
+        type: Number
+    }],
+    // this can only be 'pending','approved','rejected'
+    verification_status:{
+        type: String,
+        required:true
+    }
+},{ collection : 'reviews' });
+const Review = mongoose.model("Review", reviewSchema);
+module.exports = Review;


### PR DESCRIPTION
1. Change the 'api/posts/change_status' so that now users/admins can give optional ratings to the request resolvers when changing the request status.  The api now has the following parameters:
 req.body:{ post_id: id of the post
     group_id: id of the Group
     // For optional use case(when there is no review), resolvers_ids, resolvers_usernames and ratings may be []
     resolvers_ids: [ ids of accounts that participate to resolve the request]
     resolvers_usernames:[username of resolvers]
     ratings: [rating score for each resolver]
   }
2. A new database collection called reviews, along with review.model.js is created to store each user review.
3. Notification following this format will be sent to the group admins and co-supervisers:
decoded.username +' creates a review for users '
                                +req.body.resolvers_usernames.toString() + ' for a new resolved request.
For instance, a10 creates a review for users testInvite1,a9 for a new resolved request. 

4. The APIs for group admins to accept/decline the review is stilll in progress of implementation. 